### PR TITLE
Enhance navigation shell accessibility and docs

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -87,3 +87,12 @@ The frontend is tightly coupled with the Cloudflare ecosystem.
 * **Don’t** store sensitive information or API keys in the frontend code. Authentication relies on user-specific tokens managed by the auth flow.
 * **Don’t** embed static data like Mermaid definitions directly in components. Fetch them from the API to ensure they are always up-to-date.
 * **Don't** use the native `EventSource` API for streaming. Use `fetch` with a `ReadableStream` to have better control over the request lifecycle and error handling, as specified in the implementation details.
+
+---
+
+#### **Process Requirements**
+
+* **Always** run and pass `npm run lint`, `npm run build`, and `npx wrangler deploy --dry-run` before opening a PR.
+* Update `project_tasks.json` so that every touched task has an accurate status, notes, and completion date.
+* Keep documentation synchronized: update the current `PROMPT_PHASE_{n}.md`, add the next sequential `PROMPT_PHASE_{n+1}.md` handoff prompt, and reflect feature changes in `README.md`.
+* Capture required screenshots (desktop + mobile when UI changes are visible) and attach them to the PR description.

--- a/PROMPT_PHASE_2.md
+++ b/PROMPT_PHASE_2.md
@@ -1,34 +1,34 @@
 # Prompt Phase 2 Handoff
 
-## Summary of Tasks 1-3
+## Summary of Tasks 1-4
 - **TASK-101**: Bootstrapped the Vite + React + TypeScript workspace with Cloudflare Worker integration, Tailwind, and routing scaffolding.
 - **TASK-102**: Established the shadcn/ui design system, including theming, dark mode, and composite recipe showcase components.
 - **TASK-103**: Implemented the auth-ready data layer—centralized API client with token refresh, TanStack Query provider, Zustand auth store with session persistence, auth hooks/UI, and Cloudflare Worker auth mocks.
+- **TASK-104**: Delivered the React Router app shell with lazy-loaded feature routes, TanStack Query-powered route prefetching, WCAG-labelled desktop navigation, and a mobile sheet experience built from shadcn primitives.
 
 ## Current Project State
 - React SPA builds and lints cleanly (`npm run lint`, `npm run build`).
-- Application shell demonstrates design system elements plus an `AuthPanel` wired to mock auth endpoints.
+- Application shell now includes responsive navigation with TanStack Query prefetching, hover/focus/touch hints, and accessible labelling that mirrors the desktop and mobile patterns.
+- Feature routes (chat, kitchen hub, recipes, planner) render inside the shared shell using suspense-driven skeleton fallbacks and simulated data fetchers.
 - Zustand store persists tokens in `sessionStorage`, auto-refreshes tokens, and keeps query cache synchronized.
 - Cloudflare Worker serves `/api/health` and `/api/auth/{login,refresh,me}` mock endpoints mirroring expected JSON contracts.
-- Documentation updated to reflect the new authentication/query layer.
+- Documentation updated to reflect the new authentication/query/navigation layer.
 
-## Recommended Next Steps (Phase 2)
-1. **TASK-104**: Implement React Router app shell, navigation, and route-level code-splitting.
-2. Define feature routes (e.g., chat, kitchen hub, recipe view) and connect them to TanStack Query hooks.
-3. Expand Worker mocks for kitchen/recipe endpoints to unblock UI development.
-4. Add integration tests covering login/logout and token refresh flows (Vitest + Testing Library).
-5. Evaluate toast deduplication and query error UX once more endpoints exist.
+## Recommended Next Steps (Phase 3)
+1. **TASK-201**: Build the "My Kitchen" appliance list UI, hooking TanStack Query to Worker mocks for CRUD operations and multipart uploads.
+2. Expand Worker mocks for kitchen/recipe endpoints to unblock UI development.
+3. Add integration tests covering navigation, login/logout, and token refresh flows (Vitest + Testing Library).
+4. Evaluate toast deduplication and query error UX once more endpoints exist.
 
 ## Ready-to-Use Prompt for Next Phase
 ```
-Open project_tasks.json and continue with TASK-104.
-- Build the React Router app shell with desktop + mobile navigation using shadcn components.
-- Implement lazy-loaded route modules for the primary feature areas (chat, kitchen hub, recipes, planner).
-- Ensure navigation state reflects the active route and includes accessible labels.
-- Wire TanStack Query prefetching for likely next routes.
-- Update README and project_tasks.json (status, notes, date) when TASK-104 is complete.
-- Run `npm run lint` and `npm run build` before committing.
-- Provide screenshots of new navigation experiences.
+Open project_tasks.json and continue with TASK-201.
+- Build the Smart Kitchen Hub appliance list UI with shadcn cards, dialogs, and progress indicators.
+- Wire TanStack Query hooks to new Worker mocks for listing, creating, and deleting appliances (including multipart uploads for manuals).
+- Ensure optimistic updates keep the UI responsive and WCAG-compliant during mutations.
+- Update README, project_tasks.json (status, notes, date), and PROMPT_PHASE_3.md when TASK-201 is complete.
+- Run `npm run lint`, `npm run build`, and `wrangler deploy --dry-run` before committing.
+- Capture updated screenshots demonstrating the kitchen hub experience.
 ```
 
 ## Technical Decisions & Patterns

--- a/PROMPT_PHASE_3.md
+++ b/PROMPT_PHASE_3.md
@@ -1,0 +1,38 @@
+# Prompt Phase 3 Kickoff
+
+## Objective
+Advance EPIC-2 by delivering TASK-201: a Smart Kitchen Hub appliance list that showcases CRUD flows, multipart uploads, and responsive feedback across desktop and mobile breakpoints.
+
+## Context Recap
+- The app shell now provides accessible desktop navigation and a mobile sheet menu with TanStack Query route prefetching.
+- Feature routes for chat, kitchen hub, recipes, and planner are lazy loaded with suspense fallbacks via `src/lib/routeData.ts` mocks.
+- Authentication scaffolding (API client, Zustand store, TanStack Query provider) is live with Cloudflare Worker auth mocks.
+
+## Primary Task — TASK-201
+1. Build the "My Kitchen" appliance list UI using shadcn components (`card`, `dialog`, `form`, `progress`, `alert-dialog`).
+2. Implement TanStack Query hooks for:
+   - Listing appliances (`GET /api/kitchen/appliances`).
+   - Creating appliances with multipart uploads (`POST /api/kitchen/appliances`).
+   - Deleting appliances with confirmation (`DELETE /api/kitchen/appliances/:id`).
+3. Provide optimistic UX: progress indicators during uploads, status badges, and immediate list updates.
+4. Ensure WCAG 2.1 AA compliance (focus management, aria-labels, keyboard support) across list, forms, and dialogs.
+
+## Supporting Work
+- Expand Worker mocks in `worker/index.ts` to cover the new appliance endpoints, including simulated processing states.
+- Add integration tests (Vitest + Testing Library) that cover loading, adding, and removing appliances.
+- Revisit toast deduplication/error handling with the new mutations.
+
+## Deliverables
+- Updated UI components, hooks, and Worker mocks that fulfill TASK-201.
+- Documentation updates in `README.md` and `PROMPT_PHASE_3.md` (this file) describing the new appliance features and any configuration steps.
+- `project_tasks.json` entries updated with accurate status, notes, and completion date for TASK-201 and related subtasks.
+
+## Validation & Quality Gates
+- `npm run lint`
+- `npm run build`
+- `npx wrangler deploy --dry-run`
+- Relevant integration/unit tests (`npm run test` once introduced).
+
+## Artifacts
+- Capture fresh screenshots highlighting the Smart Kitchen Hub appliance list on desktop and mobile.
+- Include test results and deployment dry-run logs in the PR description.

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ The design system is built with shadcn/ui primitives and a shared token layer:
 
 ## Routing & navigation
 
-- `src/App.tsx` defines route-based code splitting with React Router, loading feature areas on demand.
-- `src/components/layout/app-shell.tsx` renders the shared app chrome, desktop navigation menu, and mobile sheet navigation with TanStack Query route prefetching.
+- `src/App.tsx` defines route-based code splitting with React Router, loading feature areas on demand via `React.lazy` and `Suspense`.
+- `src/components/layout/app-shell.tsx` renders the shared app chrome, desktop navigation menu, and mobile sheet navigation with TanStack Query route prefetching plus WCAG-friendly labelling for keyboard and screen-reader use.
+- Navigation automatically prefetches the two most likely next routes after each transition and hints additional data when links receive hover, focus, or touch interactions.
 - Individual route modules under `src/routes/` (chat, kitchen hub, recipes, planner) pull data via suspense-enabled hooks in `src/lib/routeData.ts` to showcase loading states and layout patterns.
 
 ## Authentication & data layer

--- a/project_tasks.json
+++ b/project_tasks.json
@@ -212,7 +212,7 @@
           "description": "Set up client-side routing with React Router v6, create app shell with navigation, and implement route-based code splitting.",
           "status": "completed",
           "completedDate": "2025-10-04",
-          "notes": "Introduced lazy-loaded feature routes, a shared AppShell with shadcn navigation menu + mobile sheet, and TanStack Query-powered route prefetching/skeleton fallbacks.",
+          "notes": "Delivered lazy-loaded feature routes inside an accessible shadcn-powered app shell with desktop navigation menu, mobile sheet, and TanStack Query prefetching plus suspense skeletons.",
           "success_criteria": "All routes are defined and navigable. Route transitions are smooth. Code is split by route. Navigation component shows active states.",
           "unit_tests": [
             "Test that all routes render correct components",

--- a/src/components/auth-panel.tsx
+++ b/src/components/auth-panel.tsx
@@ -9,7 +9,7 @@ import { selectIsAuthenticated, useAuthStore } from '@/stores/useAuthStore'
 import { Badge } from './ui/badge'
 import { Button } from './ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card'
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from './ui/form'
+import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from './ui/form'
 import { Input } from './ui/input'
 import { Skeleton } from './ui/skeleton'
 

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -83,7 +83,7 @@ function DesktopNavigation({ navItems, activeKey }: DesktopNavigationProps) {
   const queryClient = useQueryClient()
 
   return (
-    <NavigationMenu aria-label="Primary">
+    <NavigationMenu>
       <NavigationMenuList>
         {navItems.map((item) => (
           <NavigationMenuItem key={item.key}>

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -55,7 +55,7 @@ export function AppShell({ navItems }: AppShellProps) {
               <p className="text-sm font-semibold text-foreground">Culinary control center</p>
             </div>
           </div>
-          <nav className="hidden items-center gap-4 md:flex">
+          <nav aria-label="Primary" className="hidden items-center gap-4 md:flex">
             <DesktopNavigation navItems={navItems} activeKey={activeItem?.key} />
             <ThemeToggle />
           </nav>
@@ -83,7 +83,7 @@ function DesktopNavigation({ navItems, activeKey }: DesktopNavigationProps) {
   const queryClient = useQueryClient()
 
   return (
-    <NavigationMenu>
+    <NavigationMenu aria-label="Primary">
       <NavigationMenuList>
         {navItems.map((item) => (
           <NavigationMenuItem key={item.key}>
@@ -95,6 +95,7 @@ function DesktopNavigation({ navItems, activeKey }: DesktopNavigationProps) {
                     isActive ? 'bg-muted text-foreground' : 'text-muted-foreground'
                   }`
                 }
+                aria-label={`${item.label} – ${item.description}`}
                 onFocus={() => void prefetchRouteData(queryClient, item.key)}
                 onMouseEnter={() => void prefetchRouteData(queryClient, item.key)}
                 onTouchStart={() => void prefetchRouteData(queryClient, item.key)}
@@ -102,6 +103,7 @@ function DesktopNavigation({ navItems, activeKey }: DesktopNavigationProps) {
               >
                 <span aria-hidden="true">{item.icon}</span>
                 {item.label}
+                <span className="sr-only">{item.description}</span>
               </NavLink>
             </NavigationMenuLink>
           </NavigationMenuItem>
@@ -130,7 +132,7 @@ function MobileNavigation({ navItems }: MobileNavigationProps) {
       <SheetContent side="left" className="w-72 sm:max-w-xs">
         <div className="space-y-2 py-4">
           <p className="text-xs uppercase tracking-[0.35em] text-muted-foreground">Navigate</p>
-          <nav className="grid gap-2">
+          <nav aria-label="Primary mobile" className="grid gap-2">
             {navItems.map((item) => (
               <SheetClose asChild key={item.key}>
                 <NavLink
@@ -140,6 +142,7 @@ function MobileNavigation({ navItems }: MobileNavigationProps) {
                       isActive ? 'bg-muted text-foreground' : 'bg-background/80 text-muted-foreground hover:bg-background'
                     }`
                   }
+                  aria-label={`${item.label} – ${item.description}`}
                   onFocus={() => void prefetchRouteData(queryClient, item.key)}
                   onMouseEnter={() => void prefetchRouteData(queryClient, item.key)}
                   onTouchStart={() => void prefetchRouteData(queryClient, item.key)}
@@ -149,6 +152,7 @@ function MobileNavigation({ navItems }: MobileNavigationProps) {
                     <span className="font-medium text-foreground">{item.label}</span>
                     <span className="text-xs text-muted-foreground">{item.description}</span>
                   </span>
+                  <span className="sr-only">Go to the {item.label} experience</span>
                 </NavLink>
               </SheetClose>
             ))}

--- a/src/routes/kitchen-hub.tsx
+++ b/src/routes/kitchen-hub.tsx
@@ -5,7 +5,7 @@ import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
 
 import { AuthPanel } from '@/components/auth-panel'
-import { IngredientList, type Ingredient } from '@/components/ingredient-list'
+import { IngredientList } from '@/components/ingredient-list'
 import { RecipeCard } from '@/components/recipe-card'
 import { Button } from '@/components/ui/button'
 import {


### PR DESCRIPTION
## Summary
- add aria labelling and descriptive copy to the shadcn navigation shell for both desktop and mobile states
- document the navigation shell behaviour in README and phase handoff docs while introducing the next phase brief
- refresh TASK-104 metadata and AGENT process requirements to enforce testing, dry runs, and documentation updates

## Testing
- npm run lint
- npm run build
- npx wrangler deploy --dry-run

------
https://chatgpt.com/codex/tasks/task_e_68e17dfa60dc832e8e4a88fbc5e9caba