### PR TITLE
feat: add appliance manual processing polling and retry UX

### DIFF
--- a/PROMPT_PHASE_4.md
+++ b/PROMPT_PHASE_4.md
@@ -7,15 +7,21 @@
 - Refined toast deduplication and documentation across `README.md`, `PROMPT_PHASE_3.md`, and `project_tasks.json`.
 
 ## Objectives Checklist (Phase 4)
-- [ ] **TASK-202**: Implement asynchronous manual processing UI with conditional polling and status transitions.
-  - [ ] SUB-202-1: Create `useApplianceStatus` hook that polls `/api/kitchen/appliances/:id` with `refetchInterval`.
-  - [ ] SUB-202-2: Ensure polling only runs while status is QUEUED/PROCESSING and pauses otherwise.
-  - [ ] SUB-202-3: Surface badges/spinner/progress updates inside `ApplianceCard` for intermediate states.
-  - [ ] SUB-202-4: Fire deduplicated toasts when processing completes in the background.
-  - [ ] SUB-202-5: Handle error states with retry affordances in the UI and Worker mocks.
-- [ ] Update docs (`README.md`, this prompt, project_tasks.json) with new behaviours when TASK-202 completes.
+- [x] **TASK-202**: Implement asynchronous manual processing UI with conditional polling and status transitions.
+  - [x] SUB-202-1: Create `useApplianceStatus` hook that polls `/api/kitchen/appliances/:id` with `refetchInterval`.
+  - [x] SUB-202-2: Ensure polling only runs while status is QUEUED/PROCESSING and pauses otherwise.
+  - [x] SUB-202-3: Surface badges/spinner/progress updates inside `ApplianceCard` for intermediate states.
+  - [x] SUB-202-4: Fire deduplicated toasts when processing completes in the background.
+  - [x] SUB-202-5: Handle error states with retry affordances in the UI and Worker mocks.
+- [x] Update docs (`README.md`, this prompt, project_tasks.json) with new behaviours when TASK-202 completes.
 - [ ] Capture refreshed desktop + mobile screenshots of the Kitchen Hub UI once polling UX lands.
 - [ ] Run `npm run lint`, `npm run test`, `npm run build`, and `npx wrangler deploy --dry-run` before handing off.
+
+### Phase 4 progress notes
+
+- Added `useApplianceStatus` and `useRetryApplianceProcessingMutation` hooks so each card polls its detail endpoint only while manuals are queued or processing, raising deduplicated success/error toasts when background transitions occur.
+- Enhanced `ApplianceCard` with queued/processing badges, inline spinners, progress feedback, error messaging, and retry controls wired to the new Cloudflare Worker `/retry` action and failure simulations.
+- Updated Worker mocks and integration tests to cover queued → processing → ready transitions, background completion, and retry recovery paths for failed manuals.
 
 ## Technical & Architectural Notes
 - `useAppliancesQuery` already polls while any appliance is `processing`; extend or compose with a per-appliance hook to satisfy TASK-202 without over-polling.

--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ The design system is built with shadcn/ui primitives and a shared token layer:
 ## Smart kitchen hub appliances
 
 - `src/routes/kitchen-hub.tsx` renders the "My kitchen appliances" manager with shadcn cards, dialogs, progress bars, and alert dialogs to showcase listing, uploading, and deleting hardware entries across mobile and desktop breakpoints.
-- Uploads provide accessible feedback with optimistic cache updates, simulated progress, focus-safe dialog flows, aria-labels, and status badges that surface processing, ready, and error states.
-- `src/hooks/useAppliances.ts` provides TanStack Query hooks for `GET`, `POST`, and `DELETE` appliance endpoints with optimistic updates, simulated upload progress, refined toast deduplication, and background polling while manuals process.
-- `worker/index.ts` mocks `/api/kitchen/appliances` REST endpoints including multipart upload validation, delayed processing, and manual links to emulate ingestion pipelines.
-- Integration coverage for the appliance UX lives in `src/routes/__tests__/kitchen-hub.test.tsx` and exercises loading, creation, and deletion flows against mocked fetch responses.
+- Uploads provide accessible feedback with optimistic cache updates, simulated progress, focus-safe dialog flows, aria-labels, and status badges that surface queued, processing, ready, and error states with inline spinners and progress bars.
+- `src/hooks/useAppliances.ts` provides TanStack Query hooks for `GET`, `POST`, and `DELETE` appliance endpoints, composes the per-appliance `useApplianceStatus` polling hook, exposes a retry mutation, and fires deduplicated success/error toasts as manuals complete in the background.
+- `worker/index.ts` mocks `/api/kitchen/appliances` REST endpoints including multipart upload validation, delayed processing, manual links, simulated failure states, and a `/retry` action to requeue ingestion attempts.
+- Integration coverage for the appliance UX lives in `src/routes/__tests__/kitchen-hub.test.tsx` and now exercises loading, creation, deletion, polling state transitions, and retry flows against mocked fetch responses.
 
 ## Project structure
 
@@ -85,7 +85,7 @@ The `wrangler.jsonc` file enables SPA routing and directs `/api/*` requests to t
 
 ## Next steps
 
-- **TASK-202 (Smart Kitchen Hub)** – Implement dedicated polling for manual processing, expose explicit error states with retry affordances, and raise background completion toasts once ingestion finalizes.
+- Validate the manual ingestion flow against the production API once it lands and instrument telemetry around retries/completions so the async UX can be tuned with real data.
 - Expand Cloudflare Worker mocks with any additional kitchen/recipe/planner endpoints required for the next milestones.
 - Continue replacing simulated `routeData` fetchers with production-ready TanStack Query hooks routed through the Worker as endpoints mature.
 

--- a/project_tasks.json
+++ b/project_tasks.json
@@ -324,6 +324,9 @@
           "id": "TASK-202",
           "name": "Implement Asynchronous Manual Processing UI with Polling",
           "description": "Handle the asynchronous processing of appliance manuals with status polling. Show processing states and update UI automatically.",
+          "status": "completed",
+          "completedDate": "2025-10-06",
+          "notes": "Added per-appliance polling, queued/processing badges, retry UX, background completion toasts, Cloudflare Worker /retry support, and integration tests for polling + retry flows.",
           "success_criteria": "After upload, UI shows 'Processing' state. Status updates automatically without page refresh. UI transitions to 'Completed' or 'Failed' states. Error messages are clear.",
           "unit_tests": [
             "Mock status endpoint and test UI transitions through QUEUED, PROCESSING, COMPLETED",
@@ -341,11 +344,11 @@
               "Maximum polling duration to prevent infinite loops",
               "Show estimated time remaining if available from backend"
             ],
-            "status_states": "QUEUED → PROCESSING → COMPLETED or FAILED"
+            "status_states": "QUEUED → PROCESSING → READY or ERROR"
           },
           "shadcn_implementation": {
             "status_display": [
-              "badge - Show current status (Processing, Ready, Error)",
+              "badge - Show current status (Queued, Processing, Ready, Error)",
               "progress - For processing progress if percentage available",
               "spinner - Animated loading during processing",
               "alert - For error states with retry option"
@@ -358,11 +361,11 @@
             ]
           },
           "sub_tasks": [
-            {"id": "SUB-202-1", "status": "To Do", "description": "Create useApplianceStatus hook with refetchInterval polling"},
-            {"id": "SUB-202-2", "status": "To Do", "description": "Implement conditional polling (only when status is QUEUED/PROCESSING)"},
-            {"id": "SUB-202-3", "status": "To Do", "description": "Add status badges and spinner to ApplianceCard"},
-            {"id": "SUB-202-4", "status": "To Do", "description": "Show toast notification when processing completes"},
-            {"id": "SUB-202-5", "status": "To Do", "description": "Handle error states with retry option"}
+            {"id": "SUB-202-1", "status": "completed", "description": "Create useApplianceStatus hook with refetchInterval polling"},
+            {"id": "SUB-202-2", "status": "completed", "description": "Implement conditional polling (only when status is QUEUED/PROCESSING)"},
+            {"id": "SUB-202-3", "status": "completed", "description": "Add status badges and spinner to ApplianceCard"},
+            {"id": "SUB-202-4", "status": "completed", "description": "Show toast notification when processing completes"},
+            {"id": "SUB-202-5", "status": "completed", "description": "Handle error states with retry option"}
           ]
         }
       ]

--- a/src/routes/__tests__/kitchen-hub.test.tsx
+++ b/src/routes/__tests__/kitchen-hub.test.tsx
@@ -11,6 +11,7 @@ const baseTimestamp = new Date('2025-02-15T18:00:00.000Z').toISOString()
 describe('KitchenHubRoute appliance manager', () => {
   let fetchSpy: MockInstance<typeof fetch>
   let serverAppliances: Appliance[]
+  let detailSequences: Record<string, Appliance[]>
 
   beforeEach(() => {
     serverAppliances = [
@@ -25,20 +26,37 @@ describe('KitchenHubRoute appliance manager', () => {
         manualFileName: 'anova-precision-oven.pdf',
         manualUrl: 'https://manuals.menuforge.app/appliance-1/anova.pdf',
         processingProgress: 100,
+        statusDetail: null,
       },
       {
         id: 'appliance-2',
         brand: 'Breville',
         model: 'Control Freak',
         nickname: null,
-        status: 'processing',
+        status: 'queued',
         uploadedAt: baseTimestamp,
         updatedAt: baseTimestamp,
         manualFileName: 'breville.pdf',
         manualUrl: null,
-        processingProgress: 38,
+        processingProgress: 0,
+        statusDetail: null,
+      },
+      {
+        id: 'appliance-3',
+        brand: 'KitchenAid',
+        model: 'Smart Oven+',
+        nickname: 'Lab unit',
+        status: 'error',
+        uploadedAt: baseTimestamp,
+        updatedAt: baseTimestamp,
+        manualFileName: 'kitchenaid.pdf',
+        manualUrl: null,
+        processingProgress: 100,
+        statusDetail: 'Manual ingestion failed. Retry processing to rebuild capabilities.',
       },
     ]
+
+    detailSequences = {}
 
     fetchSpy = vi.spyOn(globalThis, 'fetch') as MockInstance<typeof fetch>
 
@@ -56,21 +74,78 @@ describe('KitchenHubRoute appliance manager', () => {
 
       if (url.pathname === '/api/kitchen/appliances' && method === 'POST') {
         const newAppliance: Appliance = {
-          id: 'appliance-3',
+          id: 'appliance-4',
           brand: 'GE Profile',
           model: 'Smart Wall Oven',
           nickname: 'Wall oven',
-          status: 'processing',
+          status: 'queued',
           uploadedAt: baseTimestamp,
           updatedAt: baseTimestamp,
           manualFileName: 'ge-profile.pdf',
           manualUrl: null,
-          processingProgress: 24,
+          processingProgress: 0,
+          statusDetail: null,
         }
         serverAppliances = [newAppliance, ...serverAppliances]
 
         return new Response(JSON.stringify({ appliance: newAppliance }), {
           status: 201,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+
+      if (url.pathname.match(/^\/api\/kitchen\/appliances\/.+\/retry$/) && method === 'POST') {
+        const parts = url.pathname.split('/')
+        const applianceId = parts[4] ?? ''
+        const existing = serverAppliances.find((item) => item.id === applianceId)
+
+        if (!existing) {
+          return new Response(JSON.stringify({ message: 'Not found' }), {
+            status: 404,
+            headers: { 'content-type': 'application/json' },
+          })
+        }
+
+        const updated: Appliance = {
+          ...existing,
+          status: 'queued',
+          manualUrl: null,
+          processingProgress: 0,
+          statusDetail: null,
+          updatedAt: new Date().toISOString(),
+        }
+
+        serverAppliances = serverAppliances.map((item) => (item.id === applianceId ? updated : item))
+
+        return new Response(JSON.stringify({ appliance: updated }), {
+          status: 202,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+
+      if (url.pathname.startsWith('/api/kitchen/appliances/') && method === 'GET') {
+        const applianceId = url.pathname.split('/')[4] ?? ''
+        const sequence = detailSequences[applianceId]
+        if (sequence?.length) {
+          const next = sequence.shift()!
+          serverAppliances = serverAppliances.map((item) => (item.id === applianceId ? next : item))
+          return new Response(JSON.stringify({ appliance: next }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          })
+        }
+
+        const appliance = serverAppliances.find((item) => item.id === applianceId)
+
+        if (!appliance) {
+          return new Response(JSON.stringify({ message: 'Not found' }), {
+            status: 404,
+            headers: { 'content-type': 'application/json' },
+          })
+        }
+
+        return new Response(JSON.stringify({ appliance }), {
+          status: 200,
           headers: { 'content-type': 'application/json' },
         })
       }
@@ -158,4 +233,116 @@ describe('KitchenHubRoute appliance manager', () => {
       expect(wasCalledWith('DELETE', '/api/kitchen/appliances/appliance-1')).toBe(true)
     })
   })
+
+  it(
+    'polls queued appliances until manuals are ready',
+    async () => {
+      const base = serverAppliances.find((item) => item.id === 'appliance-2')!
+      const processingUpdate: Appliance = {
+        ...base,
+        status: 'processing',
+        processingProgress: 68,
+        manualUrl: null,
+        statusDetail: null,
+        updatedAt: new Date(Date.now() + 1200).toISOString(),
+      }
+      const readyUpdate: Appliance = {
+        ...base,
+        status: 'ready',
+        processingProgress: 100,
+        manualUrl: 'https://manuals.menuforge.app/appliance-2/breville.pdf',
+        statusDetail: null,
+        updatedAt: new Date(Date.now() + 2800).toISOString(),
+      }
+
+      detailSequences['appliance-2'] = [
+        { ...base, updatedAt: new Date(Date.now() + 400).toISOString() },
+        processingUpdate,
+        readyUpdate,
+      ]
+
+      renderKitchenHub(<KitchenHubRoute />)
+
+      const cardRoot = (await screen.findByText('Control Freak')).closest('[role="listitem"]')
+      expect(cardRoot).not.toBeNull()
+      const card = within(cardRoot as HTMLElement)
+
+      await waitFor(
+        () => {
+          expect(card.getByText(/Processing manual/)).toBeInTheDocument()
+        },
+        { timeout: 6000 },
+      )
+
+      await waitFor(
+        () => {
+          expect(card.getByText('Ready')).toBeInTheDocument()
+        },
+        { timeout: 8000 },
+      )
+
+      const manualLink = card.getByRole('link', { name: /view manual/i })
+      expect(manualLink).toHaveAttribute('href', 'https://manuals.menuforge.app/appliance-2/breville.pdf')
+      expect(wasCalledWith('GET', '/api/kitchen/appliances/appliance-2')).toBe(true)
+    },
+    15000,
+  )
+
+  it(
+    'retries failed appliances and resumes polling',
+    async () => {
+      const user = userEvent.setup()
+      const base = serverAppliances.find((item) => item.id === 'appliance-3')!
+      const processingUpdate: Appliance = {
+        ...base,
+        status: 'processing',
+        processingProgress: 52,
+        manualUrl: null,
+        statusDetail: null,
+        updatedAt: new Date(Date.now() + 1200).toISOString(),
+      }
+      const readyUpdate: Appliance = {
+        ...base,
+        status: 'ready',
+        processingProgress: 100,
+        manualUrl: 'https://manuals.menuforge.app/appliance-3/kitchenaid.pdf',
+        statusDetail: null,
+        updatedAt: new Date(Date.now() + 2800).toISOString(),
+      }
+
+      detailSequences['appliance-3'] = [processingUpdate, readyUpdate]
+
+      renderKitchenHub(<KitchenHubRoute />)
+
+      const cardRoot = (await screen.findByText('KitchenAid')).closest('[role="listitem"]')
+      expect(cardRoot).not.toBeNull()
+      const card = within(cardRoot as HTMLElement)
+
+      expect(card.getByText(/Manual ingestion failed/i)).toBeInTheDocument()
+
+      await user.click(card.getByRole('button', { name: /retry processing/i }))
+
+      await waitFor(() => {
+        expect(wasCalledWith('POST', '/api/kitchen/appliances/appliance-3/retry')).toBe(true)
+      })
+
+      await waitFor(
+        () => {
+          expect(card.getByText(/Processing manual/)).toBeInTheDocument()
+        },
+        { timeout: 6000 },
+      )
+
+      await waitFor(
+        () => {
+          expect(card.getByText('Ready')).toBeInTheDocument()
+        },
+        { timeout: 8000 },
+      )
+
+      const manualLink = card.getByRole('link', { name: /view manual/i })
+      expect(manualLink).toHaveAttribute('href', 'https://manuals.menuforge.app/appliance-3/kitchenaid.pdf')
+    },
+    15000,
+  )
 })

--- a/src/routes/kitchen-hub.tsx
+++ b/src/routes/kitchen-hub.tsx
@@ -48,9 +48,11 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 
 import {
+  useApplianceStatus,
   useAppliancesQuery,
   useCreateApplianceMutation,
   useDeleteApplianceMutation,
+  useRetryApplianceProcessingMutation,
   type Appliance,
 } from '@/hooks/useAppliances'
 import { useRouteData } from '@/lib/routeData'
@@ -95,6 +97,7 @@ export default function KitchenHubRoute() {
   const appliancesQuery = useAppliancesQuery()
   const createAppliance = useCreateApplianceMutation()
   const deleteAppliance = useDeleteApplianceMutation()
+  const retryProcessing = useRetryApplianceProcessingMutation()
 
   const form = useForm<MealPlanFormValues>({
     resolver: zodResolver(mealPlanSchema),
@@ -135,6 +138,7 @@ export default function KitchenHubRoute() {
           isFetching={appliancesQuery.isFetching}
           createMutation={createAppliance}
           deleteMutation={deleteAppliance}
+          retryMutation={retryProcessing}
         />
 
         <div className="space-y-6">
@@ -251,9 +255,17 @@ interface ApplianceManagerProps {
   isFetching: boolean
   createMutation: ReturnType<typeof useCreateApplianceMutation>
   deleteMutation: ReturnType<typeof useDeleteApplianceMutation>
+  retryMutation: ReturnType<typeof useRetryApplianceProcessingMutation>
 }
 
-function ApplianceManager({ appliances, isLoading, isFetching, createMutation, deleteMutation }: ApplianceManagerProps) {
+function ApplianceManager({
+  appliances,
+  isLoading,
+  isFetching,
+  createMutation,
+  deleteMutation,
+  retryMutation,
+}: ApplianceManagerProps) {
   const [isDialogOpen, setIsDialogOpen] = useState(false)
 
   const showEmptyState = !isLoading && appliances.length === 0
@@ -299,6 +311,8 @@ function ApplianceManager({ appliances, isLoading, isFetching, createMutation, d
               appliance={appliance}
               onDelete={(id) => deleteMutation.mutate(id)}
               isDeleting={deleteMutation.isPending && deleteMutation.variables === appliance.id}
+              onRetry={() => retryMutation.mutate(appliance.id)}
+              isRetrying={retryMutation.isPending && retryMutation.variables === appliance.id}
             />
           ))}
         </div>
@@ -479,10 +493,18 @@ interface ApplianceCardProps {
   appliance: Appliance
   onDelete: (id: string) => void
   isDeleting: boolean
+  onRetry: () => void
+  isRetrying: boolean
 }
 
-function ApplianceCard({ appliance, onDelete, isDeleting }: ApplianceCardProps) {
-  const isProcessing = appliance.status === 'processing'
+function ApplianceCard({ appliance, onDelete, isDeleting, onRetry, isRetrying }: ApplianceCardProps) {
+  const { appliance: trackedAppliance, isPolling } = useApplianceStatus(appliance)
+  const status = trackedAppliance.status
+  const isQueued = status === 'queued'
+  const isProcessing = status === 'processing'
+  const isErrored = status === 'error'
+  const processingProgress = trackedAppliance.processingProgress ?? (isProcessing ? 24 : 0)
+  const manualUrl = trackedAppliance.manualUrl
 
   return (
     <Card role="listitem" className="flex h-full flex-col justify-between">
@@ -490,61 +512,97 @@ function ApplianceCard({ appliance, onDelete, isDeleting }: ApplianceCardProps) 
         <div className="flex items-start justify-between gap-3">
           <div>
             <CardTitle className="text-lg font-semibold text-foreground">
-              {appliance.brand}
+              {trackedAppliance.brand}
             </CardTitle>
-            <CardDescription className="text-sm text-muted-foreground">{appliance.model}</CardDescription>
-            {appliance.nickname ? (
-              <p className="mt-1 text-xs text-muted-foreground">Nickname: {appliance.nickname}</p>
+            <CardDescription className="text-sm text-muted-foreground">{trackedAppliance.model}</CardDescription>
+            {trackedAppliance.nickname ? (
+              <p className="mt-1 text-xs text-muted-foreground">Nickname: {trackedAppliance.nickname}</p>
             ) : null}
           </div>
-          <StatusBadge status={appliance.status} />
+          <StatusBadge status={status} isPolling={isPolling} />
         </div>
         <div className="space-y-2 text-xs text-muted-foreground">
           <p>
-            Uploaded <time dateTime={appliance.uploadedAt}>{formatDateTime(appliance.uploadedAt)}</time>
+            Uploaded <time dateTime={trackedAppliance.uploadedAt}>{formatDateTime(trackedAppliance.uploadedAt)}</time>
           </p>
           <p>
-            Updated <time dateTime={appliance.updatedAt}>{formatDateTime(appliance.updatedAt)}</time>
+            Updated <time dateTime={trackedAppliance.updatedAt}>{formatDateTime(trackedAppliance.updatedAt)}</time>
           </p>
         </div>
       </CardHeader>
       <CardContent className="space-y-3">
         <div className="flex items-center gap-2 rounded-md border border-border/60 bg-muted/20 px-3 py-2 text-sm">
           <FileText className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-          <span className="truncate" title={appliance.manualFileName ?? undefined}>
-            {appliance.manualFileName ?? 'Manual processing…'}
+          <span className="truncate" title={trackedAppliance.manualFileName ?? undefined}>
+            {trackedAppliance.manualFileName ?? 'Manual processing…'}
           </span>
         </div>
+        {isQueued ? (
+          <p className="flex items-center gap-2 text-xs text-muted-foreground" aria-live="polite">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+            Manual queued for processing…
+          </p>
+        ) : null}
         {isProcessing ? (
           <div className="space-y-1" aria-live="polite">
             <div className="flex items-center justify-between text-xs text-muted-foreground">
               <span>Processing manual…</span>
-              <span>{appliance.processingProgress ?? 24}%</span>
+              <span>{processingProgress}%</span>
             </div>
-            <Progress value={appliance.processingProgress ?? 24} aria-label="Processing progress" />
+            <Progress value={processingProgress} aria-label="Processing progress" />
+          </div>
+        ) : null}
+        {isErrored && trackedAppliance.statusDetail ? (
+          <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+            {trackedAppliance.statusDetail}
           </div>
         ) : null}
       </CardContent>
       <CardFooter className="flex flex-wrap items-center justify-between gap-2">
-        <Button
-          variant="outline"
-          className="gap-2"
-          size="sm"
-          asChild
-          disabled={!appliance.manualUrl || isProcessing}
-        >
-          <a href={appliance.manualUrl ?? '#'} aria-disabled={!appliance.manualUrl || isProcessing} target="_blank" rel="noreferrer">
-            <FileText className="h-4 w-4" aria-hidden="true" />
-            View manual
-          </a>
-        </Button>
+        <div className="flex flex-1 flex-wrap items-center gap-2">
+          <Button
+            variant="outline"
+            className="gap-2"
+            size="sm"
+            asChild
+            disabled={!manualUrl || isQueued || isProcessing || isErrored}
+          >
+            <a
+              href={manualUrl ?? '#'}
+              aria-disabled={!manualUrl || isQueued || isProcessing || isErrored}
+              target="_blank"
+              rel="noreferrer"
+            >
+              <FileText className="h-4 w-4" aria-hidden="true" />
+              View manual
+            </a>
+          </Button>
+          {isErrored ? (
+            <Button
+              variant="secondary"
+              className="gap-2"
+              size="sm"
+              onClick={onRetry}
+              disabled={isRetrying}
+            >
+              {isRetrying ? (
+                <span className="flex items-center gap-2">
+                  <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                  Retrying…
+                </span>
+              ) : (
+                'Retry processing'
+              )}
+            </Button>
+          ) : null}
+        </div>
         <AlertDialog>
           <AlertDialogTrigger asChild>
             <Button
               variant="ghost"
               className="gap-2 text-destructive hover:text-destructive"
               size="sm"
-              aria-label={`Remove ${appliance.brand} ${appliance.model}`}
+              aria-label={`Remove ${trackedAppliance.brand} ${trackedAppliance.model}`}
             >
               <Trash2 className="h-4 w-4" aria-hidden="true" />
               Remove
@@ -562,7 +620,7 @@ function ApplianceCard({ appliance, onDelete, isDeleting }: ApplianceCardProps) 
               <AlertDialogAction
                 className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
                 disabled={isDeleting}
-                onClick={() => onDelete(appliance.id)}
+                onClick={() => onDelete(trackedAppliance.id)}
               >
                 {isDeleting ? (
                   <span className="flex items-center gap-2">
@@ -581,22 +639,38 @@ function ApplianceCard({ appliance, onDelete, isDeleting }: ApplianceCardProps) 
   )
 }
 
-function StatusBadge({ status }: { status: Appliance['status'] }) {
+function StatusBadge({ status, isPolling }: { status: Appliance['status']; isPolling: boolean }) {
   if (status === 'ready') {
     return <Badge variant="secondary">Ready</Badge>
   }
 
+  if (status === 'queued') {
+    return (
+      <Badge
+        variant="outline"
+        className="flex items-center gap-2 border-sky-500 text-sky-600 dark:border-sky-400 dark:text-sky-300"
+      >
+        <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+        Queued
+      </Badge>
+    )
+  }
+
   if (status === 'processing') {
     return (
-      <Badge variant="outline" className="border-amber-500 text-amber-600 dark:border-amber-400 dark:text-amber-300">
-        Processing
+      <Badge
+        variant="outline"
+        className="flex items-center gap-2 border-amber-500 text-amber-600 dark:border-amber-400 dark:text-amber-300"
+      >
+        <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+        {isPolling ? 'Processing…' : 'Processing'}
       </Badge>
     )
   }
 
   return (
     <Badge variant="outline" className="border-destructive text-destructive">
-      Attention
+      Action needed
     </Badge>
   )
 }

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -8,7 +8,7 @@ const API_PREFIX = '/api'
 const ACCESS_TOKEN_PREFIX = 'mock-access-token-'
 const REFRESH_TOKEN_PREFIX = 'mock-refresh-token-'
 
-type ApplianceStatus = 'processing' | 'ready' | 'error'
+type ApplianceStatus = 'queued' | 'processing' | 'ready' | 'error'
 
 interface ApplianceRecord {
   id: string
@@ -21,6 +21,9 @@ interface ApplianceRecord {
   manualFileName?: string | null
   manualUrl?: string | null
   processingProgress?: number
+  statusDetail?: string | null
+  processingOutcome?: 'success' | 'error'
+  failureReason?: string | null
 }
 
 const appliancesStore = new Map<string, ApplianceRecord>()
@@ -59,6 +62,7 @@ function serializeAppliance(record: ApplianceRecord) {
     manualFileName: record.manualFileName ?? null,
     manualUrl: record.manualUrl ?? null,
     processingProgress: record.processingProgress ?? null,
+    statusDetail: record.statusDetail ?? null,
   }
 }
 
@@ -67,24 +71,53 @@ function scheduleProcessing(record: ApplianceRecord) {
   existingTimers?.forEach((timer) => clearTimeout(timer))
 
   const timers: ReturnType<typeof setTimeout>[] = []
-  record.status = 'processing'
-  record.processingProgress = record.processingProgress ?? 18
+  record.processingOutcome = record.processingOutcome ?? 'success'
+  record.status = 'queued'
+  record.statusDetail = null
+  record.processingProgress = 0
+  record.manualUrl = null
+  record.updatedAt = new Date().toISOString()
 
   timers.push(
     setTimeout(() => {
-      record.processingProgress = 60
+      record.status = 'processing'
+      record.processingProgress = Math.max(record.processingProgress ?? 0, 24)
       record.updatedAt = new Date().toISOString()
-    }, 900),
+    }, 700),
   )
 
   timers.push(
     setTimeout(() => {
-      record.status = 'ready'
-      record.processingProgress = 100
-      record.manualUrl = `${MANUAL_CDN_BASE}/${record.id}/${encodeURIComponent(record.manualFileName ?? 'manual.pdf')}`
+      if (record.status === 'processing') {
+        record.processingProgress = Math.max(record.processingProgress ?? 0, 62)
+        record.updatedAt = new Date().toISOString()
+      }
+    }, 1500),
+  )
+
+  timers.push(
+    setTimeout(() => {
+      const outcome = record.processingOutcome ?? 'success'
       record.updatedAt = new Date().toISOString()
+
+      if (outcome === 'error') {
+        record.status = 'error'
+        record.processingProgress = 100
+        record.manualUrl = null
+        record.statusDetail =
+          record.failureReason ?? 'Manual processing failed. Try again or upload a clearer PDF.'
+      } else {
+        record.status = 'ready'
+        record.processingProgress = 100
+        record.manualUrl = `${MANUAL_CDN_BASE}/${record.id}/${encodeURIComponent(
+          record.manualFileName ?? 'manual.pdf',
+        )}`
+        record.statusDetail = null
+        record.failureReason = null
+      }
+
       processingTimers.delete(record.id)
-    }, 2200),
+    }, record.processingOutcome === 'error' ? 2800 : 2200),
   )
 
   processingTimers.set(record.id, timers)
@@ -115,6 +148,8 @@ function ensureSeedAppliances() {
     manualFileName: 'anova-precision-oven.pdf',
     manualUrl: `${MANUAL_CDN_BASE}/appliance-001/anova-precision-oven.pdf`,
     processingProgress: 100,
+    statusDetail: null,
+    processingOutcome: 'success',
   }
 
   const processingAppliance: ApplianceRecord = {
@@ -122,16 +157,35 @@ function ensureSeedAppliances() {
     brand: 'Breville',
     model: 'Control Freak',
     nickname: 'Induction hob',
-    status: 'processing',
+    status: 'queued',
     uploadedAt: now,
     updatedAt: now,
     manualFileName: 'breville-control-freak.pdf',
     manualUrl: null,
-    processingProgress: 35,
+    processingProgress: 0,
+    statusDetail: null,
+    processingOutcome: 'success',
+  }
+
+  const failedAppliance: ApplianceRecord = {
+    id: 'appliance-003',
+    brand: 'KitchenAid',
+    model: 'Smart Oven+',
+    nickname: 'Lab test unit',
+    status: 'error',
+    uploadedAt: now,
+    updatedAt: now,
+    manualFileName: 'kitchenaid-smart-oven.pdf',
+    manualUrl: null,
+    processingProgress: 100,
+    statusDetail: 'Manual ingestion failed. Retry processing to rebuild capabilities.',
+    processingOutcome: 'error',
+    failureReason: 'Manual ingestion failed. Retry processing to rebuild capabilities.',
   }
 
   appliancesStore.set(readyAppliance.id, readyAppliance)
   appliancesStore.set(processingAppliance.id, processingAppliance)
+  appliancesStore.set(failedAppliance.id, failedAppliance)
   scheduleProcessing(processingAppliance)
 }
 
@@ -222,17 +276,26 @@ async function handleCreateAppliance(request: Request) {
   const now = new Date().toISOString()
   const id = crypto.randomUUID()
 
+  const manualFileName = manualFile.name || `${brand}-${model}.pdf`.replace(/\s+/g, '-').toLowerCase()
+  const shouldFail = manualFileName.toLowerCase().includes('fail')
+  const failureReason = shouldFail
+    ? 'Manual upload could not be parsed. Retry after confirming the PDF is readable.'
+    : null
+
   const record: ApplianceRecord = {
     id,
     brand,
     model,
     nickname: nickname || undefined,
-    status: 'processing',
+    status: 'queued',
     uploadedAt: now,
     updatedAt: now,
-    manualFileName: manualFile.name || `${brand}-${model}.pdf`.replace(/\s+/g, '-').toLowerCase(),
+    manualFileName,
     manualUrl: null,
-    processingProgress: 24,
+    processingProgress: 0,
+    statusDetail: null,
+    processingOutcome: shouldFail ? 'error' : 'success',
+    failureReason,
   }
 
   appliancesStore.set(id, record)
@@ -255,6 +318,36 @@ async function handleDeleteAppliance(request: Request, applianceId: string) {
   }
 
   return jsonResponse({ ok: true }, { status: 200 })
+}
+
+async function handleRetryAppliance(request: Request, applianceId: string) {
+  if (request.method !== 'POST') {
+    return errorResponse(405, 'Method Not Allowed')
+  }
+
+  ensureSeedAppliances()
+  const record = appliancesStore.get(applianceId)
+
+  if (!record) {
+    return errorResponse(404, 'Appliance not found')
+  }
+
+  const body = (await parseJsonBody<{ outcome?: 'success' | 'error'; reason?: string }>(request)) ?? {}
+  const outcome = body.outcome === 'error' ? 'error' : 'success'
+
+  record.processingOutcome = outcome
+  record.failureReason =
+    outcome === 'error'
+      ? body.reason ?? 'Manual processing failed during retry. Please try again shortly.'
+      : null
+  record.statusDetail = null
+  record.manualUrl = null
+  record.processingProgress = 0
+  record.updatedAt = new Date().toISOString()
+
+  scheduleProcessing(record)
+
+  return jsonResponse({ appliance: serializeAppliance(record) }, { status: 202 })
 }
 
 function decodeToken(prefix: string, token: string) {
@@ -436,6 +529,12 @@ export default {
       }
 
       if (segments.length > 1) {
+        const action = segments[1]
+
+        if (action === 'retry') {
+          return handleRetryAppliance(request, applianceId)
+        }
+
         return errorResponse(404, 'Endpoint not implemented in mock worker')
       }
 


### PR DESCRIPTION
## Summary
- add a per-appliance polling hook with retry support so manual processing status updates and background toasts are in sync
- enhance the Kitchen Hub cards to surface queued/processing/error badges, inline progress, and retry controls using the new hook
- extend the worker mocks, integration coverage, and documentation to describe the asynchronous lifecycle and retry flows

## Testing
- npm run lint
- npm run test
- npm run build
- npx wrangler deploy --dry-run

------
https://chatgpt.com/codex/tasks/task_e_68e29ba482b4832eb856f2210b5f6230